### PR TITLE
FD-90808 Fix for Array fragment not getting dirty

### DIFF
--- a/addon/states.js
+++ b/addon/states.js
@@ -167,7 +167,7 @@ export function fragmentDidDirty(record, key, fragment) {
   if (!record.currentState.isDeleted) {
     // Add the fragment as a placeholder in the owner record's
     // `_attributes` hash to indicate it is dirty
-    record._internalModel._recordData.setDirtyAttribute(key, fragment);
+    record._internalModel._recordData._attributes[key] = fragment;
     record.send('becomeDirty');
   }
 }

--- a/addon/states.js
+++ b/addon/states.js
@@ -167,6 +167,7 @@ export function fragmentDidDirty(record, key, fragment) {
   if (!record.currentState.isDeleted) {
     // Add the fragment as a placeholder in the owner record's
     // `_attributes` hash to indicate it is dirty
+    // FD-90808 Fix for Array fragment not getting dirty
     record._internalModel._recordData._attributes[key] = fragment;
     record.send('becomeDirty');
   }

--- a/addon/states.js
+++ b/addon/states.js
@@ -167,7 +167,8 @@ export function fragmentDidDirty(record, key, fragment) {
   if (!record.currentState.isDeleted) {
     // Add the fragment as a placeholder in the owner record's
     // `_attributes` hash to indicate it is dirty
-    // FD-90808 Fix for Array fragment not getting dirty
+    // FD-90808 Fix for Array fragment not getting dirty.
+    // https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/330
     record._internalModel._recordData._attributes[key] = fragment;
     record.send('becomeDirty');
   }


### PR DESCRIPTION
Array fragments not getting dirty even though properties are changed.

https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/330